### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/version_info/exceptions.py
+++ b/version_info/exceptions.py
@@ -1,4 +1,4 @@
 class VCSNotSupported(Exception):
 
     def __init__(self, vcs_type):
-        self.message = '%s is not supported' % vcs_type
+        self.message = '{0!s} is not supported'.format(vcs_type)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:TyMaszWeb:python-version-info?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:TyMaszWeb:python-version-info?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
